### PR TITLE
Add option to exclude external bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ pixify --name my-library
 * **--exclude** or **-e** (optional) Folder names in `--source` to ignore, for custom builds.
 * **--outputName** or **-o** (optional) The name of the output file if different from `--name`. 
 * **--watch** or **-w** (default: `false`) `true` to run watchify when running bundling.
+* **--noExternal** or **-x** (default: `false`) `true` to not bundle external modules.
 
 ## API Usage
 
@@ -46,6 +47,7 @@ pixify({
     source: './src/', 
     dest: './bin/',
     compress: true,
+    external: true,
     watch: false
 });
 
@@ -64,6 +66,7 @@ pixify('library.min.js', function(){
 * **options.dest** (`String`, default: `"./bin/"`) Output folder 
 * **options.exclude** (`String|String[]`)  List of modules to ignore from output. Useful for creating custom builds.
 * **options.watch** (`Boolean`, default: `false`)  `true` to run watchify when bundling.
+* **options.external** (`Boolean`, default: `true`) `false` to not bundle external modules.
 * **callback** (`Function`) Optional callback function when complete
 
 ## License

--- a/index.js
+++ b/index.js
@@ -11,9 +11,13 @@ var args = minimist(process.argv.slice(2), {
         s: 'source',
         n: 'name',
         o: 'outputName',
-        w: 'watch'
+        w: 'watch',
+        x: 'noExternal'
     },
-    boolean: 'watch',
+    boolean: [
+        'watch',
+        'noExternal'
+    ],
     string: [
         'name',
         'dest',
@@ -23,7 +27,8 @@ var args = minimist(process.argv.slice(2), {
     default: {
         dest: './bin/',
         source: './src/',
-        watch: false
+        watch: false,
+        noExternal: false
     }
 });
 
@@ -56,7 +61,8 @@ function bundle(options, callback) {
 bundle({
     cli: true,
     compress: false,
-    output: outputName + '.js'
+    output: outputName + '.js',
+    external: !args.noExternal
 },
 function() {
     // Don't do minify release when watching
@@ -66,7 +72,8 @@ function() {
         bundle({
             cli: true,
             compress: true,
-            output: outputName + '.min.js'
+            output: outputName + '.min.js',
+            external: !args.noExternal
         }, finish);
     }
     else {

--- a/lib/pixify.js
+++ b/lib/pixify.js
@@ -20,6 +20,7 @@ var fs = require('fs');
  * @param {Boolean} [options.compress=true] `true` to compress output
  * @param {String} [options.source='./src/'] Output source name (e.g. "./src/")
  * @param {String} [options.dest='./bin/'] Output folder (e.g. "./bin/")
+ * @param {Boolean} [options.external=true] `true` to bundle external modules.
  * @param {Array|String} [options.exclude] List of folders to exclude.
  * @param {Function} [callback] Optional callback when complete
  */
@@ -35,12 +36,14 @@ module.exports = function(options, callback) {
         dest: './bin/',
         cli: false,
         watch: false,
+        external: true,
         name: path.parse(options.output).name
     }, options);
 
     var bundler = browserify({
         entries: options.source,
         standalone: options.name,
+        bundleExternal: options.external,
         debug: true,
         cache: {},
         packageCache: {}


### PR DESCRIPTION
### Added
- Adds support for not bundling external modules. 
- Adds options.external to the API
- Adds —noExternal to the command-line arguments 
