### PR TITLE
Fix sourceRoot

### DIFF
--- a/lib/pixify.js
+++ b/lib/pixify.js
@@ -113,7 +113,7 @@ module.exports = function(options, callback) {
                     version: packageInfo.version,
                     pkg: packageInfo
                 }))
-            .pipe(sourcemaps.write('./'))
+            .pipe(sourcemaps.write('./', { sourceRoot: '' }))
             .pipe(vfs.dest(options.dest))
             .on('end', function(){
                 if (callback) {


### PR DESCRIPTION
Because of [this](https://github.com/floridoo/gulp-sourcemaps/blob/cddce0d57e462b89b7d7f7c1d1864ad2784d17ef/index.js#L191), `sourceRoot` is being set incorrectly in the sourcemaps, which in turn is why [this](https://github.com/pixijs/pixi.js/issues/3047#issuecomment-252483400) is occurring.
