### PR TITLE
Add argument `compress`  for command line.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const pixify = require('./lib/pixify');
 
 // Get the commandline arguments
 const args = minimist(process.argv.slice(2), {
-    alias: { 
+    alias: {
         e: 'exclude',
         d: 'dest',
         l: 'license',
@@ -17,11 +17,13 @@ const args = minimist(process.argv.slice(2), {
         w: 'watch',
         x: 'noExternal',
         p: 'plugin',
-        t: 'transform'
+        t: 'transform',
+        c: 'compress'
     },
     boolean: [
         'watch',
-        'noExternal'
+        'noExternal',
+        'compress'
     ],
     string: [
         'name',
@@ -36,7 +38,8 @@ const args = minimist(process.argv.slice(2), {
         dest: './bin/',
         source: './src/',
         watch: false,
-        noExternal: false
+        noExternal: false,
+        compress: true
     }
 });
 
@@ -76,7 +79,7 @@ bundle({
 function() {
     // Don't do minify release when watching
     // it's too slow because of uglify
-    if (!args.watch) {
+    if (!args.watch && args.compress) {
         // Do the release build
         bundle({
             cli: true,


### PR DESCRIPTION
Default value of `compress`  is `true` , so any current task doesn't  be affected.

I think build the dist file without compressing  is a basic feature of any build script .
Maybe it is not often ,  but should have this feature.

More talking about this feature  :  https://github.com/pixijs/pixi.js/issues/3521#issuecomment-269917692