### PR TITLE
Fix https://github.com/pixijs/pixify/issues/11

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function bundle(options, callback) {
     if (!args.watch) {
         startTime = Date.now();
     }
-    options = Object.assign({}, options, args);
+    options = Object.assign({}, args, options);
     pixify(options, function() {
         if (!args.watch) {
             // Display the output, on in non-watch mode


### PR DESCRIPTION
In current script , the  parameter `options` of `bundle` should be the highest priority.